### PR TITLE
Add appropriate tokio features to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 pin-project-lite = "0.1.4"
-tokio = { version = "0.2", features= [] }
+tokio = { version = "0.2", features = ["rt-core", "io-util"] }
 async-pipe = "0.1"
 http-body = "0.3"
 bytes = "0.5"


### PR DESCRIPTION
While working on https://github.com/routerify/routerify-websocket/issues/3, I encountered issues when trying to build the [test_stream_body.rs](https://github.com/routerify/routerify-websocket/blob/master/examples/test_stream_body.rs) example, after having updated routerify-websocket to use tokio 1.x.

```
error[E0425]: cannot find function `spawn` in crate `tokio`
   --> ~/.cargo/git/checkouts/stream-body-094892f572609189/4ca8d42/src/body.rs:104:16
    |
104 |         tokio::spawn(async move {
    |                ^^^^^ not found in `tokio`
    |
help: consider importing one of these items
    |
1   | use crate::body::io::async_write::io::sys::ext::net::raw_fd::sys_common::util::thread::spawn;
    |
1   | use std::thread::spawn;
    |

error[E0425]: cannot find function `copy` in module `io`
   --> ~/.cargo/git/checkouts/stream-body-094892f572609189/4ca8d42/src/body.rs:105:35
    |
105 |             if let Err(err) = io::copy(&mut r, &mut w).await {
    |                                   ^^^^ not found in `io`
    |
help: consider importing one of these items
    |
1   | use core::ptr::copy;
    |
1   | use crate::body::io::async_write::io::copy;
    |
1   | use crate::body::io::async_write::io::sys::ext::net::raw_fd::sys_common::fs::copy;
    |
1   | use crate::body::io::async_write::io::sys::ext::process::process::fs::copy;
    |
      and 5 other candidates
```

I am not 100% sure why the error did not arise while routerify-websocket was still using tokio 0.2 (probably due to some cargo dependency resolution shenanigans), but it seems to me that stream-body's Cargo.toml should list the features that are used:  "rt-core" is required by `tokio::spawn` and "io-util" is required by `tokio::io::copy`, both used in `body.rs`.

Having this PR merged will allow me to continue working on updating routerify-websocket. I may need to follow up with another PR on stream-body (updating to tokio 1.x and hyper 0.14) before being able to push the routerify-websocket update.